### PR TITLE
Switch from `windows` to `windows-sys` and update to 0.48

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,8 @@ default = ["with_dbus"]
 mach = "0.3"
 libc = "0.2"
 
-[target.'cfg(target_os = "windows")'.dependencies.windows]
-version = "^0.32.0"
+[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
+version = "0.48"
 features = [
     "Win32_Foundation",
     "Win32_System_Threading",


### PR DESCRIPTION
I missed this initially, otherwise would've handled it as part of the previous PR, sorry!  We currently depend on the larger `windows` crate (which can't be imported into Gecko), so this PR switches to `windows-sys` and matches Gecko's current version.