### PR TITLE
rt_linux: fix `buffer_frames` overflow panic

### DIFF
--- a/src/rt_linux.rs
+++ b/src/rt_linux.rs
@@ -271,7 +271,7 @@ pub fn set_real_time_hard_limit_internal(
         // 50ms slice. This "ought to be enough for anybody".
         audio_samplerate_hz / 20
     };
-    let budget_us = (buffer_frames * 1_000_000 / audio_samplerate_hz) as u64;
+    let budget_us = buffer_frames as u64 * 1_000_000 / audio_samplerate_hz as u64;
 
     // It's only necessary to set RLIMIT_RTTIME to something when in the child, skip it if it's a
     // remoting call.


### PR DESCRIPTION
`promote_current_thread_to_real_time()` will panic if:
- The given `audio_buffer_frames` is `0` and `audio_samplerate_hz` is greater than `85_880` OR
- The given `audio_buffer_frames` is `4295` or greater

Line 274 is where the multiplication overflow panic occurs.

https://github.com/mozilla/audio_thread_priority/blob/0399abb1401fe7e83fe9759abbd1511a5d6905ff/src/rt_linux.rs#L268-L274

For example, using a relatively normal input `0` (default) and `96,000Hz`:

```rust
// This panics.
//
// This will eventually execute:
//   96_000 / 20 = 4800
//   4800 * 1_000_000 = 4_800_000_000
//
// which overflows `u32`.
audio_thread_priority::promote_current_thread_to_real_time(0, 96_000);
```